### PR TITLE
fix(ci): use heredoc format for multi-line commit messages in GITHUB_ENV

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -63,7 +63,9 @@ jobs:
       - name: Extract latest commit message
         id: commit
         run: |
-          echo "MESSAGE=$(git log -1 --pretty=%B)" >> $GITHUB_ENV
+          echo "MESSAGE<<EOF" >> $GITHUB_ENV
+          git log -1 --pretty=%B >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
       - name: Update checklist
         uses: actions/github-script@v7


### PR DESCRIPTION
Replace single-line environment variable assignment with heredoc format to properly handle multi-line commit messages from squash merges.